### PR TITLE
Add more comprehensive support for compare operators

### DIFF
--- a/src/convert-bash.test.ts
+++ b/src/convert-bash.test.ts
@@ -148,16 +148,16 @@ describe('convert-bash', () => {
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
-                    'SET "my_var=test-!_INTERPOLATION_0!"');
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'SET "my_var=test-!_INTERPOLATION_0:~1!"');
         });
         test('should echo variable correctly with delayed expansion', () => {
             expect(convertBashToWin('my_var="test-`git log`"\necho $my_var'))
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
-                    'SET "my_var=test-!_INTERPOLATION_0!"\n' +
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'SET "my_var=test-!_INTERPOLATION_0:~1!"\n' +
                     'echo "!my_var!"');
         });
         test('should activate delayed expansion for interpolation in function', () => {
@@ -174,8 +174,8 @@ EXIT /B %ERRORLEVEL%
 
 :my_function
 SET _INTERPOLATION_0=
-FOR /f "delims=" %%a in ('git log') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")
-SET "my_var=test-!_INTERPOLATION_0!"
+FOR /f "delims=" %%a in ('git log') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")
+SET "my_var=test-!_INTERPOLATION_0:~1!"
 echo "hello from my_function: !my_var!"
 EXIT /B 0
 `);
@@ -186,8 +186,8 @@ EXIT /B 0
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
-                    'SET "my_var=test-!_INTERPOLATION_0!"');
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'SET "my_var=test-!_INTERPOLATION_0:~1!"');
         });
 
         test('should handle switch case', () => {

--- a/src/convert-bash.test.ts
+++ b/src/convert-bash.test.ts
@@ -148,7 +148,7 @@ describe('convert-bash', () => {
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
                     'SET "my_var=test-!_INTERPOLATION_0!"');
         });
         test('should echo variable correctly with delayed expansion', () => {
@@ -156,7 +156,7 @@ describe('convert-bash', () => {
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
                     'SET "my_var=test-!_INTERPOLATION_0!"\n' +
                     'echo "!my_var!"');
         });
@@ -174,7 +174,7 @@ EXIT /B %ERRORLEVEL%
 
 :my_function
 SET _INTERPOLATION_0=
-FOR /f "delims=" %%a in ('git log') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")
+FOR /f "delims=" %%a in ('git log') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")
 SET "my_var=test-!_INTERPOLATION_0!"
 echo "hello from my_function: !my_var!"
 EXIT /B 0
@@ -186,7 +186,7 @@ EXIT /B 0
                 .toEqual('@echo off\n' +
                     'setlocal EnableDelayedExpansion\n\n' +
                     'SET _INTERPOLATION_0=\n' +
-                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0! %%a")\n' +
+                    'FOR /f "delims=" %%a in (\'git log\') DO (SET "_INTERPOLATION_0=!_INTERPOLATION_0!%%a")\n' +
                     'SET "my_var=test-!_INTERPOLATION_0!"');
         });
 

--- a/src/convert-bash.test.ts
+++ b/src/convert-bash.test.ts
@@ -87,6 +87,61 @@ describe('convert-bash', () => {
                 .toEqual('@echo off\n\nIF "%my_var%" == "" (\n  echo "my_var is empty"\n) ELSE (\n  echo "my_var is not empty"\n)');
         });
 
+        test('should handle simple if -eq', () => {
+            expect(convertBashToWin('if [ "$my_var" -eq "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" EQU "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if -ne', () => {
+            expect(convertBashToWin('if [ "$my_var" -ne "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" NEQ "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if -lt', () => {
+            expect(convertBashToWin('if [ "$my_var" -lt "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" LSS "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if -le', () => {
+            expect(convertBashToWin('if [ "$my_var" -le "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" LEQ "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if -gt', () => {
+            expect(convertBashToWin('if [ "$my_var" -gt "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" GTR "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if -ge', () => {
+            expect(convertBashToWin('if [ "$my_var" -ge "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF "%my_var%" GEQ "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
+
+        test('should handle simple if not equal', () => {
+            expect(convertBashToWin('if [ ! "$my_var" == "" ]; then\n' +
+                '  echo "my_var is empty"\n' +
+                '  echo "second line"\n' +
+                'fi'))
+                .toEqual('@echo off\n\nIF NOT "%my_var%" == "" (\n  echo "my_var is empty"\n  echo "second line"\n)');
+        });
 
         test('should handle string interpolation with backticks', () => {
             expect(convertBashToWin('my_var="test-`git log`"'))

--- a/src/convert-bash.ts
+++ b/src/convert-bash.ts
@@ -154,7 +154,7 @@ class ConvertBash {
                     this.delayedExpansionActive = true;
                     const interpolationVar = `_INTERPOLATION_${this.interpolationCounter++}`;
                     this.preStatements.push(`SET ${interpolationVar}=`);
-                    this.preStatements.push(`FOR /f "delims=" %%a in ('${expansion.command}') DO (SET "${interpolationVar}=!${interpolationVar}! %%a")`);
+                    this.preStatements.push(`FOR /f "delims=" %%a in ('${expansion.command}') DO (SET "${interpolationVar}=!${interpolationVar}!%%a")`);
                     result = `${result.substring(0, expansion.loc.start)}!${interpolationVar}!${result.substring(expansion.loc.end + 1)}`;
                     break;
                 case 'ParameterExpansion':

--- a/src/convert-bash.ts
+++ b/src/convert-bash.ts
@@ -69,13 +69,30 @@ class ConvertBash {
                 return '';
             case 'Word':
                 const expandedWord = this.performExpansions(command.text, command.expansion);
-                const textWord = convertPaths(expandedWord);
+                let textWord = convertPaths(expandedWord);
 
-                if (textWord.startsWith('"') || ['==', '!='].includes(textWord)) {
-                    return textWord;
+                if (textWord.startsWith('"')) {
+                    /* Keep textWord as it is. */
+                } else if (['=='].includes(textWord)) {
+                    /* Keep textWord as it is. */
+                } else if (['!=', '-ne'].includes(textWord)) {
+                    textWord = 'NEQ';
+                } else if (['-eq'].includes(textWord)) {
+                    textWord = 'EQU';
+                } else if (['-lt'].includes(textWord)) {
+                    textWord = 'LSS';
+                } else if (['-le'].includes(textWord)) {
+                    textWord = 'LEQ';
+                } else if (['-gt'].includes(textWord)) {
+                    textWord = 'GTR';
+                } else if (['-ge'].includes(textWord)) {
+                    textWord = 'GEQ';
+                } else if (['!'].includes(textWord)) {
+                    textWord = 'NOT';
                 } else {
-                    return `"${textWord}"`;
+                    textWord = `"${textWord}"`;
                 }
+                return textWord;
             case 'AssignmentWord':
                 const expandedAssignmentWord = this.performExpansions(command.text, command.expansion);
                 const textAssignmentWord = convertPaths(expandedAssignmentWord);
@@ -185,8 +202,3 @@ export function convertBashToWin(script: string) {
         convertedCommands +
         functionDefinitions;
 }
-
-
-
-
-

--- a/src/convert-bash.ts
+++ b/src/convert-bash.ts
@@ -154,8 +154,8 @@ class ConvertBash {
                     this.delayedExpansionActive = true;
                     const interpolationVar = `_INTERPOLATION_${this.interpolationCounter++}`;
                     this.preStatements.push(`SET ${interpolationVar}=`);
-                    this.preStatements.push(`FOR /f "delims=" %%a in ('${expansion.command}') DO (SET "${interpolationVar}=!${interpolationVar}!%%a")`);
-                    result = `${result.substring(0, expansion.loc.start)}!${interpolationVar}!${result.substring(expansion.loc.end + 1)}`;
+                    this.preStatements.push(`FOR /f "delims=" %%a in ('${expansion.command}') DO (SET "${interpolationVar}=!${interpolationVar}! %%a")`);
+                    result = `${result.substring(0, expansion.loc.start)}!${interpolationVar}:~1!${result.substring(expansion.loc.end + 1)}`;
                     break;
                 case 'ParameterExpansion':
                     // expand function parameters such as `$1` (-> `%~1`) different to regular variables `$MY`(-> `%MY%` or `!MY!` if delayed expansion is active):


### PR DESCRIPTION
I tried to use the converter but ran into problems with if-compare-operators, so I extended it. Additionally, I removed the first space after the command expansion because the leading space can lead to problems in further comparisons.

**Before accepting the pull-request, please make sure that everything works as expected. Even though I added tests that passed and checked the correct functionality with the following script, you might have some additional tests to make sure, this changes don't break anything.**

```bash
if [ 1 == 1 ]; then echo 1; fi
if [ 1 != 2 ]; then echo 2; fi
if [ "hello" != "world" ]; then echo 3; fi
if [ ! "hello" == "world" ]; then echo 4; fi
if [ 1 -lt 2 ]; then echo 5; fi
if [ 2 -le 2 ]; then echo 6; fi
if [ 2 -eq 2 ]; then echo 7; fi
if [ 3 -ge 2 ]; then echo 8; fi
if [ 3 -gt 2 ]; then echo 9; fi
if [ "hello" -ne "world" ]; then echo 10; fi
if [ "hello" -eq "hello" ]; then echo 11; fi
```